### PR TITLE
Fix miss-named environment key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following configuration points are available:
   from the `SUMOLOGIC_ACCESSID` environment variable.
 - `sumologic:accessKey` - (Required) This is the Sumo Logic Access Key. It must be provided, but it can also be 
   sourced from the `SUMOLOGIC_ACCESSKEY` variable.
-- `sumologic:accessKey` - (Required) This is the API endpoint to use. See the [Sumo Logic documentation](https://help.sumologic.com/APIs/General_API_Information/Sumo_Logic_Endpoints_and_Firewall_Security) for details on 
+- `sumologic:environment` - (Required) This is the API endpoint to use. See the [Sumo Logic documentation](https://help.sumologic.com/APIs/General_API_Information/Sumo_Logic_Endpoints_and_Firewall_Security) for details on 
   which environment you should use. It must be provided, but it can be sourced from the `SUMOLOGIC_ENVIRONMENT` variable.
 
 ## Reference

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -50,7 +50,7 @@ The following configuration points are available:
   from the `SUMOLOGIC_ACCESSID` environment variable.
 - `sumologic:accessKey` - (Required) This is the Sumo Logic Access Key. It must be provided, but it can also be 
   sourced from the `SUMOLOGIC_ACCESSKEY` variable.
-- `sumologic:accessKey` - (Required) This is the API endpoint to use. See the [Sumo Logic documentation](https://help.sumologic.com/APIs/General_API_Information/Sumo_Logic_Endpoints_and_Firewall_Security) for details on 
+- `sumologic:environment` - (Required) This is the API endpoint to use. See the [Sumo Logic documentation](https://help.sumologic.com/APIs/General_API_Information/Sumo_Logic_Endpoints_and_Firewall_Security) for details on 
   which environment you should use. It must be provided, but it can be sourced from the `SUMOLOGIC_ENVIRONMENT` variable.
 
 ## Reference


### PR DESCRIPTION
The config variable for environment was accidentally named accessKey in the docs